### PR TITLE
Player process -> physics_process

### DIFF
--- a/scripts/characters/Player.gd
+++ b/scripts/characters/Player.gd
@@ -44,7 +44,7 @@ func _ready():
     _handle_transportation()
     _set_up_camera()
 
-func _process(delta):
+func _physics_process(delta):
     match state:
         MOVE:
             move_state(delta)
@@ -61,7 +61,7 @@ func apply_damage(damage : float) -> void:
         Player.health = remaining_health
 
 func _die() -> void:
-    self.set_process(false)
+    self.set_physics_process(false)
     _display_you_died_text()
     # go to title screen after 5 seconds
 


### PR DESCRIPTION
Tiny PR to address this discrepancy. Inspired by https://github.com/robwhitaker/godot-wild-jam-33/pull/13#discussion_r637529397.

Everything works the same. The only diff is `physics_process` is supposed to be more consistent than `process`.