### PR TITLE
Clean up TitleScreen

### DIFF
--- a/scenes/rooms/TitleScreen.tscn
+++ b/scenes/rooms/TitleScreen.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://assets/images/your_heroes_are_dead.png" type="Texture" id=1]
-[ext_resource path="res://scenes/rooms/TitleScreen.gd" type="Script" id=2]
+[ext_resource path="res://scripts/utils/TitleScreen.gd" type="Script" id=2]
 [ext_resource path="res://assets/images/big_grass.png" type="Texture" id=3]
 [ext_resource path="res://assets/images/press_space_to_start.png" type="Texture" id=4]
 

--- a/scripts/utils/TitleScreen.gd
+++ b/scripts/utils/TitleScreen.gd
@@ -1,7 +1,7 @@
 extends MarginContainer
 
-func _process(delta):
-    if Input.is_key_pressed(KEY_SPACE):
+func _unhandled_input(event):
+    if event is InputEventKey && event.scancode==KEY_SPACE:
         var next_scene_position = Vector2(20, 90)
         var next_scene_direction = "right"
         var next_scene_path = "res://scenes/rooms/Start.tscn"


### PR DESCRIPTION
Simply relocate the `TitleScreen.gd` to the `scripts/utils` folder where it should've been all along.