### PR TITLE
Clean up unused player attack animations

### DIFF
--- a/scenes/characters/Player.tscn
+++ b/scenes/characters/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=59 format=2]
+[gd_scene load_steps=55 format=2]
 
 [ext_resource path="res://scripts/characters/Player.gd" type="Script" id=1]
 [ext_resource path="res://assets/images/player_all.png" type="Texture" id=2]
@@ -10,78 +10,6 @@ radius = 6.20772
 height = 8.91072
 
 [sub_resource type="Animation" id=2]
-resource_name = "AttackDown"
-length = 0.4
-tracks/0/type = "method"
-tracks/0/path = NodePath(".")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0.4 ),
-"transitions": PoolRealArray( 1 ),
-"values": [ {
-"args": [  ],
-"method": "attack_animation_finish"
-} ]
-}
-
-[sub_resource type="Animation" id=3]
-resource_name = "AttackLeft"
-length = 0.4
-tracks/0/type = "method"
-tracks/0/path = NodePath(".")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0.4 ),
-"transitions": PoolRealArray( 1 ),
-"values": [ {
-"args": [  ],
-"method": "attack_animation_finish"
-} ]
-}
-
-[sub_resource type="Animation" id=4]
-resource_name = "AttackRight"
-length = 0.4
-tracks/0/type = "method"
-tracks/0/path = NodePath(".")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0.4 ),
-"transitions": PoolRealArray( 1 ),
-"values": [ {
-"args": [  ],
-"method": "attack_animation_finish"
-} ]
-}
-
-[sub_resource type="Animation" id=5]
-resource_name = "AttackUp"
-length = 0.4
-tracks/0/type = "method"
-tracks/0/path = NodePath(".")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0.4 ),
-"transitions": PoolRealArray( 1 ),
-"values": [ {
-"args": [  ],
-"method": "attack_animation_finish"
-} ]
-}
-
-[sub_resource type="Animation" id=6]
 length = 0.1
 loop = true
 tracks/0/type = "value"
@@ -97,7 +25,7 @@ tracks/0/keys = {
 "values": [ 0 ]
 }
 
-[sub_resource type="Animation" id=7]
+[sub_resource type="Animation" id=3]
 resource_name = "IdleDown_carry"
 length = 0.1
 loop = true
@@ -114,7 +42,7 @@ tracks/0/keys = {
 "values": [ 5 ]
 }
 
-[sub_resource type="Animation" id=8]
+[sub_resource type="Animation" id=4]
 length = 0.1
 loop = true
 tracks/0/type = "value"
@@ -130,7 +58,7 @@ tracks/0/keys = {
 "values": [ 30 ]
 }
 
-[sub_resource type="Animation" id=9]
+[sub_resource type="Animation" id=5]
 resource_name = "IdleLeft_carry"
 length = 0.1
 loop = true
@@ -147,7 +75,7 @@ tracks/0/keys = {
 "values": [ 35 ]
 }
 
-[sub_resource type="Animation" id=10]
+[sub_resource type="Animation" id=6]
 length = 0.1
 loop = true
 tracks/0/type = "value"
@@ -163,7 +91,7 @@ tracks/0/keys = {
 "values": [ 20 ]
 }
 
-[sub_resource type="Animation" id=11]
+[sub_resource type="Animation" id=7]
 resource_name = "IdleRight_carry"
 length = 0.1
 loop = true
@@ -180,7 +108,7 @@ tracks/0/keys = {
 "values": [ 25 ]
 }
 
-[sub_resource type="Animation" id=12]
+[sub_resource type="Animation" id=8]
 length = 0.1
 loop = true
 tracks/0/type = "value"
@@ -196,7 +124,7 @@ tracks/0/keys = {
 "values": [ 10 ]
 }
 
-[sub_resource type="Animation" id=13]
+[sub_resource type="Animation" id=9]
 resource_name = "IdleUp_carry"
 length = 0.1
 loop = true
@@ -213,7 +141,7 @@ tracks/0/keys = {
 "values": [ 15 ]
 }
 
-[sub_resource type="Animation" id=14]
+[sub_resource type="Animation" id=10]
 length = 0.5
 loop = true
 tracks/0/type = "value"
@@ -229,7 +157,7 @@ tracks/0/keys = {
 "values": [ 0, 1, 2, 3, 4 ]
 }
 
-[sub_resource type="Animation" id=15]
+[sub_resource type="Animation" id=11]
 resource_name = "RunDown_carry"
 length = 0.5
 loop = true
@@ -246,7 +174,7 @@ tracks/0/keys = {
 "values": [ 5, 6, 7, 8, 9 ]
 }
 
-[sub_resource type="Animation" id=16]
+[sub_resource type="Animation" id=12]
 length = 0.5
 loop = true
 tracks/0/type = "value"
@@ -262,7 +190,7 @@ tracks/0/keys = {
 "values": [ 30, 31, 32, 33, 34 ]
 }
 
-[sub_resource type="Animation" id=17]
+[sub_resource type="Animation" id=13]
 resource_name = "RunLeft_carry"
 length = 0.5
 loop = true
@@ -279,7 +207,7 @@ tracks/0/keys = {
 "values": [ 35, 36, 37, 38, 39 ]
 }
 
-[sub_resource type="Animation" id=18]
+[sub_resource type="Animation" id=14]
 length = 0.5
 loop = true
 tracks/0/type = "value"
@@ -295,7 +223,7 @@ tracks/0/keys = {
 "values": [ 20, 21, 22, 23, 24 ]
 }
 
-[sub_resource type="Animation" id=19]
+[sub_resource type="Animation" id=15]
 resource_name = "RunRight_carry"
 length = 0.5
 loop = true
@@ -312,7 +240,7 @@ tracks/0/keys = {
 "values": [ 25, 26, 27, 28, 29 ]
 }
 
-[sub_resource type="Animation" id=20]
+[sub_resource type="Animation" id=16]
 length = 0.5
 loop = true
 tracks/0/type = "value"
@@ -328,7 +256,7 @@ tracks/0/keys = {
 "values": [ 10, 11, 12, 13, 14 ]
 }
 
-[sub_resource type="Animation" id=21]
+[sub_resource type="Animation" id=17]
 resource_name = "RunUp_carry"
 length = 0.5
 loop = true
@@ -345,101 +273,109 @@ tracks/0/keys = {
 "values": [ 15, 16, 17, 18, 19 ]
 }
 
-[sub_resource type="AnimationNodeAnimation" id=22]
+[sub_resource type="AnimationNodeAnimation" id=18]
 animation = "IdleLeft"
 
-[sub_resource type="AnimationNodeAnimation" id=23]
+[sub_resource type="AnimationNodeAnimation" id=19]
 animation = "IdleDown"
 
-[sub_resource type="AnimationNodeAnimation" id=24]
+[sub_resource type="AnimationNodeAnimation" id=20]
 animation = "IdleRight"
 
-[sub_resource type="AnimationNodeAnimation" id=25]
+[sub_resource type="AnimationNodeAnimation" id=21]
 animation = "IdleUp"
 
-[sub_resource type="AnimationNodeBlendSpace2D" id=26]
-blend_point_0/node = SubResource( 22 )
+[sub_resource type="AnimationNodeBlendSpace2D" id=22]
+blend_point_0/node = SubResource( 18 )
 blend_point_0/pos = Vector2( -1, 0 )
-blend_point_1/node = SubResource( 23 )
+blend_point_1/node = SubResource( 19 )
 blend_point_1/pos = Vector2( 0, 1.1 )
-blend_point_2/node = SubResource( 24 )
+blend_point_2/node = SubResource( 20 )
 blend_point_2/pos = Vector2( 1, 0 )
-blend_point_3/node = SubResource( 25 )
+blend_point_3/node = SubResource( 21 )
 blend_point_3/pos = Vector2( 0, -1.1 )
 min_space = Vector2( -1, -1.1 )
 max_space = Vector2( 1, 1.1 )
 snap = Vector2( 0.01, 0.01 )
 blend_mode = 1
 
-[sub_resource type="AnimationNodeAnimation" id=27]
+[sub_resource type="AnimationNodeAnimation" id=23]
 animation = "IdleDown_carry"
 
-[sub_resource type="AnimationNodeAnimation" id=28]
+[sub_resource type="AnimationNodeAnimation" id=24]
 animation = "IdleUp_carry"
 
-[sub_resource type="AnimationNodeAnimation" id=29]
+[sub_resource type="AnimationNodeAnimation" id=25]
 animation = "IdleRight_carry"
 
-[sub_resource type="AnimationNodeAnimation" id=30]
+[sub_resource type="AnimationNodeAnimation" id=26]
 animation = "IdleLeft"
 
-[sub_resource type="AnimationNodeBlendSpace2D" id=31]
-blend_point_0/node = SubResource( 27 )
+[sub_resource type="AnimationNodeBlendSpace2D" id=27]
+blend_point_0/node = SubResource( 23 )
 blend_point_0/pos = Vector2( 0, 1.1 )
-blend_point_1/node = SubResource( 28 )
+blend_point_1/node = SubResource( 24 )
 blend_point_1/pos = Vector2( 0, -1.1 )
-blend_point_2/node = SubResource( 29 )
+blend_point_2/node = SubResource( 25 )
 blend_point_2/pos = Vector2( 1, 0 )
-blend_point_3/node = SubResource( 30 )
+blend_point_3/node = SubResource( 26 )
 blend_point_3/pos = Vector2( -1, 0 )
 
-[sub_resource type="AnimationNodeAnimation" id=32]
+[sub_resource type="AnimationNodeAnimation" id=28]
 animation = "RunLeft"
 
-[sub_resource type="AnimationNodeAnimation" id=33]
+[sub_resource type="AnimationNodeAnimation" id=29]
 animation = "RunDown"
 
-[sub_resource type="AnimationNodeAnimation" id=34]
+[sub_resource type="AnimationNodeAnimation" id=30]
 animation = "RunRight"
 
-[sub_resource type="AnimationNodeAnimation" id=35]
+[sub_resource type="AnimationNodeAnimation" id=31]
 animation = "RunUp"
 
-[sub_resource type="AnimationNodeBlendSpace2D" id=36]
-blend_point_0/node = SubResource( 32 )
+[sub_resource type="AnimationNodeBlendSpace2D" id=32]
+blend_point_0/node = SubResource( 28 )
 blend_point_0/pos = Vector2( -1, 0 )
-blend_point_1/node = SubResource( 33 )
+blend_point_1/node = SubResource( 29 )
 blend_point_1/pos = Vector2( 0, 1.1 )
-blend_point_2/node = SubResource( 34 )
+blend_point_2/node = SubResource( 30 )
 blend_point_2/pos = Vector2( 1, 0 )
-blend_point_3/node = SubResource( 35 )
+blend_point_3/node = SubResource( 31 )
 blend_point_3/pos = Vector2( 0, -1.1 )
 min_space = Vector2( -1, -1.1 )
 max_space = Vector2( 1, 1.1 )
 blend_mode = 1
 
-[sub_resource type="AnimationNodeAnimation" id=37]
+[sub_resource type="AnimationNodeAnimation" id=33]
 animation = "RunDown_carry"
 
-[sub_resource type="AnimationNodeAnimation" id=38]
+[sub_resource type="AnimationNodeAnimation" id=34]
 animation = "RunUp_carry"
 
-[sub_resource type="AnimationNodeAnimation" id=39]
+[sub_resource type="AnimationNodeAnimation" id=35]
 animation = "RunLeft_carry"
 
-[sub_resource type="AnimationNodeAnimation" id=40]
+[sub_resource type="AnimationNodeAnimation" id=36]
 animation = "RunRight_carry"
 
-[sub_resource type="AnimationNodeBlendSpace2D" id=41]
-blend_point_0/node = SubResource( 37 )
+[sub_resource type="AnimationNodeBlendSpace2D" id=37]
+blend_point_0/node = SubResource( 33 )
 blend_point_0/pos = Vector2( 0, 1.1 )
-blend_point_1/node = SubResource( 38 )
+blend_point_1/node = SubResource( 34 )
 blend_point_1/pos = Vector2( 0, -1.1 )
-blend_point_2/node = SubResource( 39 )
+blend_point_2/node = SubResource( 35 )
 blend_point_2/pos = Vector2( -1, 0 )
-blend_point_3/node = SubResource( 40 )
+blend_point_3/node = SubResource( 36 )
 blend_point_3/pos = Vector2( 1, 0 )
 blend_mode = 1
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=38]
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=39]
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=40]
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=41]
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=42]
 
@@ -449,37 +385,29 @@ blend_mode = 1
 
 [sub_resource type="AnimationNodeStateMachineTransition" id=45]
 
-[sub_resource type="AnimationNodeStateMachineTransition" id=46]
-
-[sub_resource type="AnimationNodeStateMachineTransition" id=47]
-
-[sub_resource type="AnimationNodeStateMachineTransition" id=48]
-
-[sub_resource type="AnimationNodeStateMachineTransition" id=49]
-
-[sub_resource type="AnimationNodeStateMachine" id=50]
-states/Idle/node = SubResource( 26 )
+[sub_resource type="AnimationNodeStateMachine" id=46]
+states/Idle/node = SubResource( 22 )
 states/Idle/position = Vector2( 466.125, 93.8496 )
-states/IdleCarry/node = SubResource( 31 )
+states/IdleCarry/node = SubResource( 27 )
 states/IdleCarry/position = Vector2( 466.125, 181.85 )
-states/Run/node = SubResource( 36 )
+states/Run/node = SubResource( 32 )
 states/Run/position = Vector2( 662, 93.8496 )
-states/RunCarry/node = SubResource( 41 )
+states/RunCarry/node = SubResource( 37 )
 states/RunCarry/position = Vector2( 662, 181.85 )
-transitions = [ "Idle", "Run", SubResource( 42 ), "Run", "Idle", SubResource( 43 ), "Idle", "IdleCarry", SubResource( 44 ), "IdleCarry", "Idle", SubResource( 45 ), "Run", "RunCarry", SubResource( 46 ), "RunCarry", "Run", SubResource( 47 ), "RunCarry", "IdleCarry", SubResource( 48 ), "IdleCarry", "RunCarry", SubResource( 49 ) ]
+transitions = [ "Idle", "Run", SubResource( 38 ), "Run", "Idle", SubResource( 39 ), "Idle", "IdleCarry", SubResource( 40 ), "IdleCarry", "Idle", SubResource( 41 ), "Run", "RunCarry", SubResource( 42 ), "RunCarry", "Run", SubResource( 43 ), "RunCarry", "IdleCarry", SubResource( 44 ), "IdleCarry", "RunCarry", SubResource( 45 ) ]
 start_node = "Idle"
 graph_offset = Vector2( 0, 25.4324 )
 
-[sub_resource type="AnimationNodeStateMachinePlayback" id=51]
+[sub_resource type="AnimationNodeStateMachinePlayback" id=47]
 
-[sub_resource type="CircleShape2D" id=52]
+[sub_resource type="CircleShape2D" id=48]
 radius = 31.7889
 
-[sub_resource type="CapsuleShape2D" id=53]
+[sub_resource type="CapsuleShape2D" id=49]
 radius = 14.699
 height = 48.9292
 
-[sub_resource type="CapsuleShape2D" id=54]
+[sub_resource type="CapsuleShape2D" id=50]
 height = 39.967
 
 [node name="Player" type="KinematicBody2D"]
@@ -492,7 +420,6 @@ position = Vector2( 0, -21 )
 texture = ExtResource( 2 )
 hframes = 5
 vframes = 8
-frame = 34
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2( 0.445, 1 )
@@ -500,31 +427,27 @@ rotation = -1.5708
 shape = SubResource( 1 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-anims/AttackDown = SubResource( 2 )
-anims/AttackLeft = SubResource( 3 )
-anims/AttackRight = SubResource( 4 )
-anims/AttackUp = SubResource( 5 )
-anims/IdleDown = SubResource( 6 )
-anims/IdleDown_carry = SubResource( 7 )
-anims/IdleLeft = SubResource( 8 )
-anims/IdleLeft_carry = SubResource( 9 )
-anims/IdleRight = SubResource( 10 )
-anims/IdleRight_carry = SubResource( 11 )
-anims/IdleUp = SubResource( 12 )
-anims/IdleUp_carry = SubResource( 13 )
-anims/RunDown = SubResource( 14 )
-anims/RunDown_carry = SubResource( 15 )
-anims/RunLeft = SubResource( 16 )
-anims/RunLeft_carry = SubResource( 17 )
-anims/RunRight = SubResource( 18 )
-anims/RunRight_carry = SubResource( 19 )
-anims/RunUp = SubResource( 20 )
-anims/RunUp_carry = SubResource( 21 )
+anims/IdleDown = SubResource( 2 )
+anims/IdleDown_carry = SubResource( 3 )
+anims/IdleLeft = SubResource( 4 )
+anims/IdleLeft_carry = SubResource( 5 )
+anims/IdleRight = SubResource( 6 )
+anims/IdleRight_carry = SubResource( 7 )
+anims/IdleUp = SubResource( 8 )
+anims/IdleUp_carry = SubResource( 9 )
+anims/RunDown = SubResource( 10 )
+anims/RunDown_carry = SubResource( 11 )
+anims/RunLeft = SubResource( 12 )
+anims/RunLeft_carry = SubResource( 13 )
+anims/RunRight = SubResource( 14 )
+anims/RunRight_carry = SubResource( 15 )
+anims/RunUp = SubResource( 16 )
+anims/RunUp_carry = SubResource( 17 )
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource( 50 )
+tree_root = SubResource( 46 )
 anim_player = NodePath("../AnimationPlayer")
-parameters/playback = SubResource( 51 )
+parameters/playback = SubResource( 47 )
 parameters/Idle/blend_position = Vector2( -0.000819027, -0.00635839 )
 parameters/IdleCarry/blend_position = Vector2( 0, 0 )
 parameters/Run/blend_position = Vector2( -1, 0 )
@@ -555,7 +478,7 @@ collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DetectionRadius"]
 position = Vector2( 0.111366, -9.04911 )
-shape = SubResource( 52 )
+shape = SubResource( 48 )
 
 [node name="InteractionRadius" type="Area2D" parent="."]
 position = Vector2( 0, -12 )
@@ -564,7 +487,7 @@ collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractionRadius"]
 position = Vector2( 0, -2.19919 )
-shape = SubResource( 53 )
+shape = SubResource( 49 )
 
 [node name="Hurtbox" type="Area2D" parent="."]
 position = Vector2( 0, -12 )
@@ -573,7 +496,7 @@ collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
 position = Vector2( -0.297295, -8.1758 )
-shape = SubResource( 54 )
+shape = SubResource( 50 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2( 0, -5 )


### PR DESCRIPTION
Removes all player `Attack___` animations from the animation player.

Follow up to https://github.com/robwhitaker/godot-wild-jam-33/pull/22