### PR TITLE
Fix bug where player could not carry the body between rooms

### DIFF
--- a/scripts/objects/DeadBodyInteraction.gd
+++ b/scripts/objects/DeadBodyInteraction.gd
@@ -7,5 +7,5 @@ func unselect():
     pass
 
 func interact():
-    Scene.player.has_body = true
+    Scene.player.pickup_body()
     owner.queue_free()


### PR DESCRIPTION
The issue was occurring because the `pickup_body` helper function on the `Player` was not being used to pickup the body, so the global `Player.has_body` was never being set to `true`.

Game breaking since the whole objective is to carry the body back to the start.