### PR TITLE
Fix failing scene transitions in release builds

### DIFF
--- a/scripts/globals/SceneChanger.gd
+++ b/scripts/globals/SceneChanger.gd
@@ -15,7 +15,8 @@ func change_scene(position : Vector2, direction : String, scene_path : String, d
     yield(get_tree().create_timer(delay), "timeout")
     animationPlayer.play("fade")
     yield(animationPlayer, "animation_finished")
-    assert(get_tree().change_scene(scene_path) == OK)
+    #warning-ignore:return_value_discarded
+    get_tree().change_scene(scene_path)
     animationPlayer.play_backwards("fade")
     yield(animationPlayer, "animation_finished")
     emit_signal("scene_changed")


### PR DESCRIPTION
This bug made `SceneChanger` fail to load new scenes in release builds, making it impossible to leave the title screen or travel between forest rooms.